### PR TITLE
add amqp integration

### DIFF
--- a/sources/modules/iot-broker/pom.xml
+++ b/sources/modules/iot-broker/pom.xml
@@ -20,7 +20,11 @@
 	</properties>
 
 	<dependencies>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
+		
 		<dependency>
 			<groupId>com.minsait.onesait.platform</groupId>
 			<artifactId>onesaitplatform-business-services</artifactId>

--- a/sources/modules/iot-broker/src/main/java/com/minsait/onesait/platform/iotbroker/plugable/impl/gateway/reference/amqp/RabbitMqConfig.java
+++ b/sources/modules/iot-broker/src/main/java/com/minsait/onesait/platform/iotbroker/plugable/impl/gateway/reference/amqp/RabbitMqConfig.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright Indra Soluciones Tecnologías de la Información, S.L.U.
+ * 2013-2019 SPAIN
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.minsait.onesait.platform.iotbroker.plugable.impl.gateway.reference.amqp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minsait.onesait.platform.iotbroker.plugable.interfaces.gateway.GatewayInfo;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurer;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+@ConditionalOnProperty(prefix = "onesaitplatform.iotbroker.plugable.gateway.amqp", name = "enable", havingValue = "true")
+@Configuration
+@EnableRabbit
+public class RabbitMqConfig implements RabbitListenerConfigurer {
+
+  public static final String AMQP_GATEWAY = "amqp_gateway";
+  public static final String MESSAGE_QUEUE = "message";
+  public static final String TOPIC_MESSAGE_QUEUE = "topic/message";
+  public static final String TOPIC_SUBSCRIPTION_QUEUE = "topic/subscription";
+  public static final String TOPIC_COMMAND_QUEUE = "topic/command";
+
+  @Bean
+  Queue topicCommandQueue() {
+    return new Queue(TOPIC_COMMAND_QUEUE, true);
+  }
+
+  @Bean
+  Queue topicSubscriptionQueue() {
+    return new Queue(TOPIC_SUBSCRIPTION_QUEUE, true);
+  }
+
+  @Bean
+  Queue topicMessageQueue() {
+    return new Queue(TOPIC_MESSAGE_QUEUE, true);
+  }
+
+  @Bean
+  Queue messageQueue() {
+    return new Queue(MESSAGE_QUEUE, true);
+  }
+
+  @Bean
+  TopicExchange iotBrokerExchange() {
+    return new TopicExchange("iotbroker");
+  }
+
+  @Bean
+  List<Binding> binding() {
+
+    return Arrays.asList(BindingBuilder.bind(messageQueue()).to(iotBrokerExchange()).with(MESSAGE_QUEUE),
+                         BindingBuilder.bind(topicMessageQueue()).to(iotBrokerExchange()).with(TOPIC_MESSAGE_QUEUE),
+                         BindingBuilder.bind(topicSubscriptionQueue()).to(iotBrokerExchange()).with(TOPIC_SUBSCRIPTION_QUEUE),
+                         BindingBuilder.bind(topicCommandQueue()).to(iotBrokerExchange()).with(TOPIC_COMMAND_QUEUE));
+  }
+
+  @Override
+  public void configureRabbitListeners(final RabbitListenerEndpointRegistrar registrar) {
+    registrar.setMessageHandlerMethodFactory(messageHandlerMethodFactory());
+  }
+
+  @Bean
+  public DefaultMessageHandlerMethodFactory messageHandlerMethodFactory() {
+    DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
+    factory.setMessageConverter(consumerJackson2MessageConverter());
+    return factory;
+  }
+
+  @Bean
+  public MappingJackson2MessageConverter consumerJackson2MessageConverter() {
+    return new MappingJackson2MessageConverter();
+  }
+
+  @Bean
+  public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+    final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setMessageConverter(messageConverter());
+    return rabbitTemplate;
+  }
+
+  @Bean
+  public MessageConverter messageConverter() {
+    ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+    return new Jackson2JsonMessageConverter(mapper);
+  }
+
+  public static GatewayInfo getGatewayInfo() {
+    final GatewayInfo info = new GatewayInfo();
+    info.setName(AMQP_GATEWAY);
+    info.setProtocol("AMQP");
+
+    return info;
+  }
+}

--- a/sources/modules/iot-broker/src/main/java/com/minsait/onesait/platform/iotbroker/plugable/impl/gateway/reference/amqp/RabbitMqHandler.java
+++ b/sources/modules/iot-broker/src/main/java/com/minsait/onesait/platform/iotbroker/plugable/impl/gateway/reference/amqp/RabbitMqHandler.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright Indra Soluciones Tecnologías de la Información, S.L.U.
+ * 2013-2019 SPAIN
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.minsait.onesait.platform.iotbroker.plugable.impl.gateway.reference.amqp;
+
+import com.minsait.onesait.platform.comms.protocol.SSAPMessage;
+import com.minsait.onesait.platform.comms.protocol.body.SSAPBodyReturnMessage;
+import com.minsait.onesait.platform.iotbroker.processor.GatewayNotifier;
+import com.minsait.onesait.platform.iotbroker.processor.MessageProcessor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@Slf4j
+public class RabbitMqHandler {
+
+  private final GatewayNotifier subscription;
+  private final MessageProcessor processor;
+  private RabbitTemplate rabbitTemplate;
+
+  @Autowired
+  public RabbitMqHandler(GatewayNotifier subscription,
+                         MessageProcessor processor,
+                         RabbitTemplate rabbitTemplate){
+
+    this.subscription = subscription;
+    this.processor = processor;
+    this.rabbitTemplate = rabbitTemplate;
+  }
+
+
+  @PostConstruct
+  public void init() {
+    subscription.addSubscriptionListener(RabbitMqConfig.AMQP_GATEWAY, s ->
+      rabbitTemplate.convertAndSend(RabbitMqConfig.TOPIC_SUBSCRIPTION_QUEUE, s)
+    );
+
+    subscription.addCommandListener(RabbitMqConfig.AMQP_GATEWAY, c -> {
+      rabbitTemplate.convertAndSend(RabbitMqConfig.TOPIC_COMMAND_QUEUE, c);
+      return new SSAPMessage<>();
+    });
+  }
+
+  @RabbitListener(queues = RabbitMqConfig.MESSAGE_QUEUE)
+  public void handleMessage(SSAPMessage message){
+    final SSAPMessage<SSAPBodyReturnMessage> response = processor.process(message, RabbitMqConfig.getGatewayInfo());
+
+    rabbitTemplate.convertAndSend(RabbitMqConfig.TOPIC_MESSAGE_QUEUE, response);
+  }
+
+}

--- a/sources/modules/iot-broker/src/main/resources/application.yml
+++ b/sources/modules/iot-broker/src/main/resources/application.yml
@@ -32,6 +32,12 @@ spring:
     max-idle: 5
     min-idle: 5
     removeAbandoned: true
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    virtualHost:
       
   jpa:
       # The SQL dialect makes Hibernate generate better SQL for the chosen database
@@ -95,6 +101,8 @@ onesaitplatform: #Config onesait Platform specific
   iotbroker.plugable:
     gateway:
       stomp:
+        enable: true
+      amqp:
         enable: true
       moquette:
         enable: true


### PR DESCRIPTION
This pull request is simple and first try to implement amqp protocol on iot-broker project.
Things to consider before approving PR:
 * AMQP is a queue-based protocol not a channel-based like MQTT and STOMP, with this implementation the project has queues and all messages sent to these queues will be executed and all subscribers will receive all responses from all producer. Maybe that's not a good idea.
 * Must create testes

Test Implementation:

You must start some projects before iot-broker:

 * cache-server: https://github.com/onesaitplatform/onesaitplatform-revolution-magrathea/tree/master/sources/modules/cache-server
 * semantic-inf-broker: https://github.com/onesaitplatform/onesaitplatform-revolution-magrathea/tree/master/sources/modules/semantic-inf-broker
 * iot-broker: https://github.com/onesaitplatform/onesaitplatform-revolution-magrathea/tree/master/sources/modules/iot-broker

 After compiling all these projects you must start mysql database and rabbitmq, to do this you can use docker with this compose file:
```
version: '3'

services:

  mysql-development:
    image: mysql:latest
    environment:
      MYSQL_ROOT_PASSWORD: changeIt!
      MYSQL_DATABASE: onesaitplatform_config
    ports:
      - "3306:3306"
  rabbitMq-developent:
    image: rabbitmq:3-management
    environment:
      RABBITMQ_DEFAULT_USER: guest
      RABBITMQ_DEFAULT_PASS: guest
    ports:
      - "5672:5672"
      - "15672:15672"
```

Save above content in a docker-compose.yml file and run:
```
docker-compose up -d
```

After these steps you need to start config-init project to create db tables
https://github.com/onesaitplatform/onesaitplatform-revolution-magrathea/tree/master/sources/modules/config-init

Now you can start all the services in order and start iot-broker to test implementation.

